### PR TITLE
Do not pass nil to s-contains?

### DIFF
--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -129,7 +129,7 @@ virtualenv. PATH should be a list of strings specifiying directories."
                   (lambda (s) (not (s-contains?
                                     (file-name-as-directory
                                      (expand-file-name
-                                      venv-location)) s)))
+                                      venv-location)) (or s default-directory))))
                 (lambda (execs)
                   (not (-filter (lambda (locs)
                                   (s-contains?


### PR DESCRIPTION
It is tolerated (and sometimes expected) for the exec-path list to contain a nil value, to represent the default directory.

With previous code, this resulted in s-contains? emitting the error "Wrong type argument: stringp, nil" -- this fix passes the default directory when it encounters a nil value in exec-path.
