### PR TITLE
Improved python-mode hook given in README to be more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ automatically, we can just add a python-mode hook:
 ```lisp
 (add-hook 'python-mode-hook (lambda ()
                               (hack-local-variables)
-                              (venv-workon project-venv-name)))
+                              (when (boundp 'project-venv-name)
+                                (venv-workon project-venv-name))))
 ```
 
 The call to `hack-local-variables` is necessary because by default


### PR DESCRIPTION
venv-workon should only be run when a project-venv-name has been defined, which is not always the case.
