### PR TITLE
Use $WORKON_HOME as venv-location

### DIFF
--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -45,7 +45,7 @@
   :group 'python)
 
 (defcustom venv-location
-  (expand-file-name "~/.virtualenvs/")
+  (expand-file-name (or (getenv "WORKON_HOME") "~/.virtualenvs/"))
   "The location(s) of your virtualenvs. This
 can be either a string, which indicates a single directory in which
 you keep all your virutalenvs, or a list of strings, in which case it


### PR DESCRIPTION
[virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/) uses `WORKON_HOME` environment variable to locate virtualenvs, so it might be a good idea to use it also as default `venv-location`
