### PR TITLE
Add interactive function to set venv location

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ much of the functionality of Doug Hellmann's
   Notice that the final directory of each path has a different name.
   The mode uses this fact to disambiguate virtualenvs from each other,
   so for now it is required.
+* You can also change easily the virtual environment location with
+  `M-x venv-set-location`. This is particularly useful when working with
+  tools such as [tox](https://testrun.org/tox/latest/) that generate virtual
+  environments dynamically.
 
 ## What do activating and deactivating actually do?
 

--- a/test/virtualenvwrapper-test.el
+++ b/test/virtualenvwrapper-test.el
@@ -124,3 +124,11 @@
      (should (equal preactivated "yes"))
      (should (equal postactivated "yes"))
      (should (equal name venv-tmp-env)))))
+
+(ert-deftest venv-set-location-works ()
+  (let ((expected-venv-location "test location")
+        (original-venv-location venv-location))
+    (should (equal venv-location (expand-file-name "~/.virtualenvs/")))
+    (venv-set-location expected-venv-location)
+    (should (equal venv-location expected-venv-location))
+    (setq venv-location original-venv-location)))

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -211,6 +211,18 @@ prompting the user with the string PROMPT"
     (message "virtualenv deactivated")))
 
 ;;;###autoload
+(defun venv-set-location (&optional location)
+  "Set where to look for virtual environments to LOCATION.
+This is useful e.g. when using tox."
+  (interactive)
+  (when (not location)
+    (setq location (read-directory-name "New virtualenv: ")))
+  (venv-deactivate)
+  (setq venv-location location)
+  (when (called-interactively-p 'interactive)
+    (message (concat "Virtualenv location: " location))))
+
+;;;###autoload
 (defun venv-workon (&optional name)
   "Interactively switch to virtualenv NAME. Prompts for name if called
 interactively."

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -1,6 +1,6 @@
 ;;; virtualenvwrapper.el --- a featureful virtualenv tool for Emacs
 
-;; Copyright (C) 2013 James J Porter
+;; Copyright (C) 2013 - 2015 James J Porter and [contributors](https://github.com/porterjamesj/virtualenvwrapper.el/graphs/contributors)
 
 ;; Author: James J Porter <porterjamesj@gmail.com>
 ;; URL: http://github.com/porterjamesj/virtualenvwrapper.el

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -4,7 +4,7 @@
 
 ;; Author: James J Porter <porterjamesj@gmail.com>
 ;; URL: http://github.com/porterjamesj/virtualenvwrapper.el
-;; Version: 20131514
+;; Version: 20151123
 ;; Keywords: python, virtualenv, virtualenvwrapper
 ;; Package-Requires: ((dash "1.5.0") (s "1.6.1"))
 


### PR DESCRIPTION
When using tools like [tox](https://testrun.org/tox/latest/) that create
virtual environments in different locations, it's useful to change
venv-location to take advantage of the virtualenvwrapper goodies.

This commit adds the venv-set-location interactive function that allows
you to do just that.