### PR TITLE
Run pdb with `python -m` when in a venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,16 @@ All will do what would expect.
 Prompts for the name of a virtualenv and activates it as described
 above. Can also be called noninteractively as `(venv-workon "name")`.
 
+When called, it sets `gud-pdb-command-name` to `python -m pdb` so that
+`M-x pdb` can be used inside the virtual environment.
+
 #### `venv-deactivate`
 
 Deactivates your current virtualenv, undoing everything that `venv-workon`
 did. This can also be called noninteractively as `(venv-deactivate)`.
+
+When called, it sets `gud-pdb-command-name` to its default value
+(usually `pdb`).
 
 #### `venv-mkvirtualenv`
 

--- a/test/virtualenvwrapper-test.el
+++ b/test/virtualenvwrapper-test.el
@@ -45,6 +45,8 @@
    venv-tmp-env
    (venv-deactivate)
    (venv-workon venv-tmp-env)
+   ;; M-x pdb should ask to run "python -m pdb"
+   (should (equal gud-pdb-command-name "python -m pdb"))
    ;; we store the name correctly
    (should (equal venv-current-name venv-tmp-env))
    ;; we change the path for python mode
@@ -60,6 +62,8 @@
   (with-temp-env
    venv-tmp-env
    (venv-deactivate)
+   ;; M-x pdb should ask to run "pdb"
+   (should (equal gud-pdb-command-name "pdb"))
    ;; we remove the name correctly
    (should (equal venv-current-name nil))
    ;; we change the python path back

--- a/test/virtualenvwrapper-test.el
+++ b/test/virtualenvwrapper-test.el
@@ -8,6 +8,9 @@
 (load (expand-file-name "virtualenvwrapper.el" default-directory))
 (require 's)
 
+;; needed to ensure that gud-pdb-command-name is not void.
+(require 'gud)
+
 (setq venv-tmp-env "emacs-venvwrapper-test")
 
 (defmacro with-temp-location (&rest forms)

--- a/test/virtualenvwrapper-test.el
+++ b/test/virtualenvwrapper-test.el
@@ -8,9 +8,6 @@
 (load (expand-file-name "virtualenvwrapper.el" default-directory))
 (require 's)
 
-;; needed to ensure that gud-pdb-command-name is not void.
-(require 'gud)
-
 (setq venv-tmp-env "emacs-venvwrapper-test")
 
 (defmacro with-temp-location (&rest forms)

--- a/test/virtualenvwrapper-test.el
+++ b/test/virtualenvwrapper-test.el
@@ -43,10 +43,7 @@
 (ert-deftest venv-workon-works ()
   (with-temp-env
    venv-tmp-env
-   (setq  gud-pdb-command-name "test")
    (venv-deactivate)
-   ;; M-x pdb should ask to run "test"
-   (should (equal gud-pdb-command-name "test"))
    (venv-workon venv-tmp-env)
    ;; M-x pdb should ask to run "python -m pdb"
    (should (equal gud-pdb-command-name "python -m pdb"))
@@ -64,10 +61,9 @@
 (ert-deftest venv-deactivate-works ()
   (with-temp-env
    venv-tmp-env
-   (setq  gud-pdb-command-name "test")
    (venv-deactivate)
-   ;; M-x pdb should ask to run "test"
-   (should (equal gud-pdb-command-name "test"))
+   ;; M-x pdb should ask to run "pdb"
+   (should (equal gud-pdb-command-name "pdb"))
    ;; we remove the name correctly
    (should (equal venv-current-name nil))
    ;; we change the python path back

--- a/test/virtualenvwrapper-test.el
+++ b/test/virtualenvwrapper-test.el
@@ -43,7 +43,10 @@
 (ert-deftest venv-workon-works ()
   (with-temp-env
    venv-tmp-env
+   (setq  gud-pdb-command-name "test")
    (venv-deactivate)
+   ;; M-x pdb should ask to run "test"
+   (should (equal gud-pdb-command-name "test"))
    (venv-workon venv-tmp-env)
    ;; M-x pdb should ask to run "python -m pdb"
    (should (equal gud-pdb-command-name "python -m pdb"))
@@ -61,9 +64,10 @@
 (ert-deftest venv-deactivate-works ()
   (with-temp-env
    venv-tmp-env
+   (setq  gud-pdb-command-name "test")
    (venv-deactivate)
-   ;; M-x pdb should ask to run "pdb"
-   (should (equal gud-pdb-command-name "pdb"))
+   ;; M-x pdb should ask to run "test"
+   (should (equal gud-pdb-command-name "test"))
    ;; we remove the name correctly
    (should (equal venv-current-name nil))
    ;; we change the python path back

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -84,13 +84,11 @@ are stored if you use virtualenvwrapper in the shell."
 
 (defun venv--set-venv-gud-pdb-command-name ()
   "When in a virtual env, call pdb as \\[python -m pdb]."
-    (custom-set-variables
-   '(gud-pdb-command-name "python -m pdb")))
+  (setq gud-pdb-command-name "python -m pdb"))
 
 (defun venv--set-system-gud-pdb-command-name ()
   "Set the system \\[pdb] command."
-  (custom-set-variables
-   '(gud-pdb-command-name venv-system-gud-pdb-command-name)))
+  (setq gud-pdb-command-name venv-system-gud-pdb-command-name))
 
 
 (defun venv-clear-history ()

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -21,6 +21,9 @@
 (require 'dash)
 (require 's)
 
+;; needed to set gud-pdb-command-name
+(require 'gud)
+
 ;; customizable variables
 
 (defgroup virtualenvwrapper nil

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -72,6 +72,8 @@ are stored if you use virtualenvwrapper in the shell."
 
 (defvar venv-current-dir nil "Directory of current virtualenv.")
 
+(defvar venv-system-gud-pdb-command-name gud-pdb-command-name
+  "Whatever `gud-pdb-command-name' is (usually \\[pdb]).")
 
 ;; copy from virtualenv.el
 (defvar venv-executables-dir
@@ -79,6 +81,17 @@ are stored if you use virtualenvwrapper in the shell."
   "The name of the directory containing executables. It is system dependent.")
 
 ;; internal utility functions
+
+(defun venv--set-venv-gud-pdb-command-name ()
+  "When in a virtual env, call pdb as \\[python -m pdb]."
+    (custom-set-variables
+   '(gud-pdb-command-name "python -m pdb")))
+
+(defun venv--set-system-gud-pdb-command-name ()
+  "Set the system \\[pdb] command."
+  (custom-set-variables
+   '(gud-pdb-command-name venv-system-gud-pdb-command-name)))
+
 
 (defun venv-clear-history ()
   (setq venv-history nil))
@@ -206,6 +219,7 @@ prompting the user with the string PROMPT"
   (setq venv-current-name nil)
   (setq venv-current-dir nil)
   (setq eshell-path-env (getenv "PATH"))
+  (venv--set-system-gud-pdb-command-name)
   (run-hooks 'venv-postdeactivate-hook)
   (when (called-interactively-p 'interactive)
     (message "virtualenv deactivated")))
@@ -260,6 +274,7 @@ interactively."
   ;; keep eshell path in sync
   (setq eshell-path-env (getenv "PATH"))
   (setenv "VIRTUAL_ENV" venv-current-dir)
+  (venv--set-venv-gud-pdb-command-name)
   (run-hooks 'venv-postactivate-hook)
   (when (called-interactively-p 'interactive)
     (message (concat "Switched to virtualenv: " venv-current-name))))


### PR DESCRIPTION
Virtual environments do not offer the `pdb` executable, but we can still
run `pdb` by invoking `python -m pdb`.

In Emacs `M-x pdb` offers to run the usual `pdb` executable, so let's
change that when we invoke `venv-workon`. When we run `venv-deactivate`
we restore the original behavior.

This could have been implemented using `advice-add`, but unfortunately
that is not compatible with versions of Emacs <= 24.3 (where `defadvice`
should be used).

This commit addresses issue #26.