### PR TITLE
Package helm-virtualenvwrapper so it can be submitted to MELPA

### DIFF
--- a/contrib/helm-virtualenvwrapper.el
+++ b/contrib/helm-virtualenvwrapper.el
@@ -11,10 +11,13 @@
 ;;
 ;; Then C-c v away
 
+;;; Code:
+
+(require 'virtualenvwrapper)
 
 ;;;###autoload
 (defun helm-venv-workon ()
-  "Like venv-work, for helm."
+  "Like venv-workon, for helm."
   (interactive)
   (helm :sources '(helm-source-venv)))
 
@@ -26,3 +29,6 @@
     (action . (("activate" . venv-workon)))
     (persistent-action . venv-workon)
     (persistent-help . "Activate the virtualenv.")))
+
+(provide 'helm-virtualenvwrapper)
+;;; helm-virtualenvwrapper.el ends here


### PR DESCRIPTION
It would be nice to have helm-virtualenwrapper.el in [MELPA](https://github.com/milkypostman/melpa), but before submitting a recipe for it, it must be made a proper package.

The melpa recipe is pretty easy:

    (helm-virtualenvwrapper
    :fetcher github
    :repo "porterjames/virtualenvwrapper.el"
    :files ("contrib/helm-virtualenvwrapper.el"))

but right now it fails because `helm-virtualenvwrapper.el` is not recognized as a package.

It that's OK, after this is merged I can submit the recipe to the melpa repo.