### PR TITLE
Use $WORKON_HOME even if Emacs wasn't started from a terminal.

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,6 +4,7 @@
 
 (depends-on "s" "1.6.1")
 (depends-on "dash" "1.5.0")
+(depends-on "exec-path-from-shell" "1.10")
 
 (development
  (depends-on "ert-runner"))

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/porterjamesj/virtualenvwrapper.el
 ;; Version: 20131514
 ;; Keywords: python, virtualenv, virtualenvwrapper
-;; Package-Requires: ((dash "1.5.0") (s "1.6.1"))
+;; Package-Requires: ((dash "1.5.0") (s "1.6.1") (exec-path-from-shell "1.10"))
 
 ;;; Commentary:
 
@@ -20,6 +20,7 @@
 
 (require 'dash)
 (require 's)
+(require 'exec-path-from-shell)
 
 ;; customizable variables
 
@@ -28,7 +29,8 @@
   :group 'python)
 
 (defcustom venv-location
-  (expand-file-name (or (getenv "WORKON_HOME") "~/.virtualenvs/"))
+  (expand-file-name (or (exec-path-from-shell-getenv "WORKON_HOME")
+                        "~/.virtualenvs/"))
   "The location(s) of your virtualenvs. This
 can be either a string, which indicates a single directory in which
 you keep all your virutalenvs, or a list of strings, in which case it


### PR DESCRIPTION
`getenv` only extracts variables in the environment that Emacs was
started from. If a user sets $WORKON_HOME in .bashrc or .zshrc then
`(getenv "WORKON_HOME")` will return nil.