### PR TITLE
Add support to auto-activate virtualenv found in projetile-project-root

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,42 @@ mode-hooks are run before directory local variables are set, so we
 have to do that explicitly in the hook in order to have access to
 them.
 
+### Automatically activating a virtualenv when using projectile
+
+If you're using [projectile](https://github.com/bbatsov/projectile)
+there's an easier way to automatically activate a virtualenv when
+entering a project.
+
+You just have to call `(venv-projectile-auto-workon)` after switching
+projects, this can be achieved hooking the call to the action
+`projectile-switch-project-action` like this:
+
+```lisp
+(setq projectile-switch-project-action 'venv-projectile-auto-workon)
+```
+
+If you relay on another use for this action, then just add a `lambda`
+instead:
+
+```lisp
+(setq projectile-switch-project-action
+      '(lambda ()
+         (venv-projectile-auto-workon)
+         (projectile-find-file)))
+```
+
+As long as a virtualenv is found in the `projectile-project-root` and
+whose name is `.venv` it will be automatically activated. If you tend
+to name your virtualenvs differently (e.g. _pyenv_ or _.virtual_) just
+be sure to add those extra names to the `venv-dirlookup-names` list.
+
+```lisp
+(setq venv-dirlookup-names '(".venv" "pyenv" ".virtual"))
+```
+
+You can add as many names you need, the first one found in the current
+project will be activated.
+
 ### Displaying the currently active virtualenv on the mode line
 
 The name of the currently active virtualenv is stored in the variable

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -40,11 +40,11 @@ The default location is ~/.virtualenvs/, which is where your virtualenvs
 are stored if you use virtualenvwrapper in the shell."
   :group 'virtualenvwrapper)
 
-(defcustom 'venv-dirlookup-names
+(defcustom venv-dirlookup-names
   '(".venv")
   "Virtualenvs to search in the projectile-project-root
 to activate when one of them is found."
-  :type (repeat :tag "List of directories" file)
+  :type '(repeat file)
   :group 'virtualenvwrapper)
 
 ;; hooks

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -40,6 +40,13 @@ The default location is ~/.virtualenvs/, which is where your virtualenvs
 are stored if you use virtualenvwrapper in the shell."
   :group 'virtualenvwrapper)
 
+(defcustom 'venv-dirlookup-names
+  '(".venv")
+  "Virtualenvs to search in the projectile-project-root
+to activate when one of them is found."
+  :type (repeat :tag "List of directories" file)
+  :group 'virtualenvwrapper)
+
 ;; hooks
 
 (defvar venv-premkvirtualenv-hook nil
@@ -93,6 +100,13 @@ are stored if you use virtualenvwrapper in the shell."
   "Set the system \\[pdb] command."
   (setq gud-pdb-command-name venv-system-gud-pdb-command-name))
 
+(defun venv-projectile-auto-workon ()
+  "If a venv in the projetile root exists, calls venv-workon it.
+Set your common venvs names in `venv-dirlookup-names'"
+  (let ((path (--first
+               (file-exists-p (concat (projectile-project-root) it))
+               venv-dirlookup-names)))
+    (when path (venv-workon path))))
 
 (defun venv-clear-history ()
   (setq venv-history nil))


### PR DESCRIPTION
Now it is possible to automatically activate a virtualenv located in the
root of a projectile project `(projectile-project-root)` however this
isn't done magical, the user has to call `(venv-projectile-auto-workon)`
in some point after entering the project, i.e. via projectile-hooks,
python-mode hooks or the action `projectile-switch-project-action` which
is the recommended way and thus documented in the README.md.

By default it will detect only virtualenvs whose name is ".venv" but
the user can expand the options by settings all the desired names in
the `venv-dirlookup-names` list, this is all documented in the README.

Fixes #24.