### PR TITLE
Use modern Travis environment and EVM for Emacs versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,22 @@
 language: emacs-lisp
+sudo: false
+dist: trusty
 before_install:
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs-snapshot-el emacs-snapshot-gtk emacs-snapshot;
-    fi
-  - if [ "$EMACS" = 'emacs24' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs24 emacs24-el emacs24-common-non-dfsg;
-    fi
+  - git clone https://github.com/rejeep/evm.git ~/.evm
+  - evm config path /tmp
+  - evm install $EVM_EMACS
+  - evm use $EVM_EMACS
   - sudo apt-get install -y python-pip
   - sudo pip install virtualenv
   - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
-  - export PATH="/home/travis/.cask/bin:$PATH"
   - cask
 env:
-  - EMACS=emacs24
+  global:
+      - PATH="~/.evm/bin:~/.cask/bin:$PATH"
+  matrix:
+    - EVM_EMACS=emacs-24.5-travis
+    - EVM_EMACS=emacs-25.1-travis
+    - EVM_EMACS=emacs-25.2-travis
+    - EVM_EMACS=emacs-git-snapshot-travis
 script:
   cask exec ert-runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - EVM_EMACS=emacs-24.5-travis
     - EVM_EMACS=emacs-25.1-travis
     - EVM_EMACS=emacs-25.2-travis
+    - EVM_EMACS=emacs-25.3-travis
     - EVM_EMACS=emacs-git-snapshot-travis
 script:
   cask exec ert-runner


### PR DESCRIPTION
I noticed that the PPA was rather out of date, and have used EVM
before. I'm about to update its snapshot version and add 25.3 as well.