### PR TITLE
Allow interpreter to be set non-interactively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
       - python-pip
 env:
   global:
-    - PATH="~/.evm/bin:~/.cask/bin:$PATH"
+    - PATH=~/.evm/bin:~/.cask/bin:$PATH
   matrix:
     - EVM_EMACS=emacs-24.5-travis
     - EVM_EMACS=emacs-25.1-travis
@@ -20,6 +20,7 @@ before_install:
   - evm config path /tmp
   - evm install $EVM_EMACS
   - evm use $EVM_EMACS
+  - hash -r
   - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
   - cask install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,26 @@
-language: emacs-lisp
+language: generic
 sudo: false
 dist: trusty
-before_install:
-  - git clone https://github.com/rejeep/evm.git ~/.evm
-  - evm config path /tmp
-  - evm install $EVM_EMACS
-  - evm use $EVM_EMACS
-  - sudo apt-get install -y python-pip
-  - sudo pip install virtualenv
-  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
-  - cask
+addons:
+  apt:
+    packages:
+      - python-pip
 env:
   global:
-      - PATH="~/.evm/bin:~/.cask/bin:$PATH"
+    - PATH="~/.evm/bin:~/.cask/bin:$PATH"
   matrix:
     - EVM_EMACS=emacs-24.5-travis
     - EVM_EMACS=emacs-25.1-travis
     - EVM_EMACS=emacs-25.2-travis
     - EVM_EMACS=emacs-25.3-travis
     - EVM_EMACS=emacs-git-snapshot-travis
+before_install:
+  - pip install -U --user virtualenv
+  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+  - evm config path /tmp
+  - evm install $EVM_EMACS
+  - evm use $EVM_EMACS
+  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+  - cask install
 script:
-  cask exec ert-runner
+  - cask exec ert-runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - EVM_EMACS=emacs-25.1-travis
     - EVM_EMACS=emacs-25.2-travis
     - EVM_EMACS=emacs-25.3-travis
-    - EVM_EMACS=emacs-git-snapshot-travis
+    # - EVM_EMACS=emacs-git-snapshot-travis
 before_install:
   - pip install -U --user virtualenv
   - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - evm use $EVM_EMACS
   - hash -r
   - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+  - cask exec emacs --version
   - cask install
 script:
   - cask exec ert-runner

--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package "virtualenvwrapper" "20140315" "a featureful virtualenv tool for Emacs")
@@ -7,4 +8,5 @@
 
 (development
  (depends-on "ert-runner")
- (depends-on "noflet"))
+ (depends-on "noflet")
+ (depends-on "with-simulated-input"))

--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ list), then the new virtualenv will be created in the current default
 directory. Also callable noninteractively as `(venv-mkvirtualenv
 "name")`.
 
+#### `venv-mkvirtualenv-using`
+
+Supplying a prefix command (`C-u`) to `venv-mkvirtualenv` will prompt
+for a Python interpreter to use. You can use this function to specify
+the interpreter noninteractively.
+
 #### `venv-rmvirtualenv`
 
 Prompt for the name of a virutalenv and delete it. Also callable

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -324,20 +324,22 @@ throwing an error if not"
   )
 
 ;;;###autoload
-(defun venv-mkvirtualenv (&rest names)
-"Create new virtualenvs NAMES. If venv-location is a single
-directory, the new virtualenvs are made there; if it is a list of
-directories, the new virtualenvs are made in the current
-default-directory."
+(defun venv-mkvirtualenv-using (interpreter &rest names)
+  "Create new virtualenvs NAMES using INTERPRETER. If venv-location
+is a single directory, the new virtualenvs are made there; if it
+is a list of directories, the new virtualenvs are made in the
+current `default-directory'."
   (interactive)
   (venv--check-executable)
-  (let ((parent-dir (if (stringp venv-location)
+  (let* ((foo (if current-prefix-arg
+                         (read-string "Python executable: ")
+                       interpreter))
+        (parent-dir (if (stringp venv-location)
                         (file-name-as-directory
                          (expand-file-name venv-location))
                       default-directory))
-        (python-exe-arg (when current-prefix-arg
-                          (concat "--python="
-                                  (read-string "Python executable: " "python"))))
+        (python-exe-arg (when foo
+                          (concat "--python=" foo)))
         (names (if names names
                  (list (read-from-minibuffer "New virtualenv: ")))))
     ;; map over all the envs we want to make
@@ -355,6 +357,15 @@ default-directory."
         (message (concat "Created virtualenv: " it))))
     ;; workon the last venv we made
     (venv-workon (car (last names)))))
+
+;;;###autoload
+(defun venv-mkvirtualenv (&rest names)
+  "Create new virtualenvs NAMES. If venv-location is a single
+directory, the new virtualenvs are made there; if it is a list of
+directories, the new virtualenvs are made in the current
+`default-directory'."
+  (interactive)
+  (apply #'venv-mkvirtualenv-using nil names))
 
 ;;;###autoload
 (defun venv-rmvirtualenv (&rest names)


### PR DESCRIPTION
This is a suggestion for accomplishing programmatic interpreter
selection without breaking backward-compatibility (perhaps there is a
better way?).

Tests are included, with some also testing interactive
behaviour. These ones use `with-simulated-input`, which requires a
newer emacs-24. Hence, this PR depends on #94. If this is undesirable
for some reason, the interactive tests could be wrapped in
`condition-case`.