### PR TITLE
Clearer prompt in venv-set-location

### DIFF
--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -254,7 +254,7 @@ prompting the user with the string PROMPT"
 This is useful e.g. when using tox."
   (interactive)
   (when (not location)
-    (setq location (read-directory-name "New virtualenv: ")))
+    (setq location (read-directory-name "New virtualenv location: " venv-location)))
   (venv-deactivate)
   (setq venv-location location)
   (when (called-interactively-p 'interactive)


### PR DESCRIPTION
Clarify that we're prompting for a directory that contains
virtualenvs, not a path to a virtualenv.

Also default to the current value rather than current-directory.