### PR TITLE
Fix interactive mode of venv-mkvirtualenv-using

### DIFF
--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -329,7 +329,7 @@ throwing an error if not"
 is a single directory, the new virtualenvs are made there; if it
 is a list of directories, the new virtualenvs are made in the
 current `default-directory'."
-  (interactive)
+  (interactive "P")
   (venv--check-executable)
   (let* ((foo (if current-prefix-arg
                          (read-string "Python executable: ")


### PR DESCRIPTION
The "P" argument to `interactive` was missing.