### PR TITLE
Make the virtualenv command customizable

### DIFF
--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -31,9 +31,9 @@
   :group 'python)
 
 (defcustom venv-virtualenv-command "virtualenv"
-       "The command to use to run virtualenv."
-       :type '(string)
-       :group 'virtualenvwrapper)
+  "The command to use to run virtualenv."
+  :type '(string)
+  :group 'virtualenvwrapper)
 
 (defcustom venv-location
   (expand-file-name (or (getenv "WORKON_HOME") "~/.virtualenvs/"))

--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -30,6 +30,11 @@
   "Virtualenvwrapper for Emacs."
   :group 'python)
 
+(defcustom venv-virtualenv-command "virtualenv"
+       "The command to use to run virtualenv."
+       :type '(string)
+       :group 'virtualenvwrapper)
+
 (defcustom venv-location
   (expand-file-name (or (getenv "WORKON_HOME") "~/.virtualenvs/"))
   "The location(s) of your virtualenvs. This
@@ -319,7 +324,7 @@ identifying a virtualenv."
 (defun venv--check-executable ()
   "Verify that there is a virtualenv executable available,
 throwing an error if not"
-  (unless (executable-find "virtualenv")
+  (unless (executable-find venv-virtualenv-command)
     (error "There doesn't appear to be a virtualenv executable on
     your exec path. Ensure that you have virtualenv installed and
     that the exec-path variable is set such that virtualenv can
@@ -357,7 +362,7 @@ current `default-directory'."
       (when (-contains? (venv-get-candidates) it)
         (error "A virtualenv with this name already exists!"))
       (run-hooks 'venv-premkvirtualenv-hook)
-      (shell-command (concat "virtualenv " python-exe-arg " " parent-dir it))
+      (shell-command (concat venv-virtualenv-command " " python-exe-arg " " parent-dir it))
       (when (listp venv-location)
         (add-to-list 'venv-location (concat parent-dir it)))
       (venv-with-virtualenv it


### PR DESCRIPTION
cygwin (https://cygwin.com) has OOTB support for python virtualenv since Feb. 17, 2019.  See https://cygwin.com/ml/cygwin-announce/2019-02/msg00013.html

The specific virtualenv command is installed with a version suffix:

2:30 PM [503]> ls -lt /usr/bin/virtualenv*
-rwxr-xr-x 1 VZE Domänen-Benutzer 214 Feb 15 18:45 /usr/bin/virtualenv-3.7*
-rwxr-xr-x 1 VZE Domänen-Benutzer 214 Feb 15 18:45 /usr/bin/virtualenv-3.6*
-rwxr-xr-x 1 VZE Domänen-Benutzer 214 Feb 15 18:45 /usr/bin/virtualenv-3.5*
-rwxr-xr-x 1 VZE Domänen-Benutzer 214 Feb 15 18:45 /usr/bin/virtualenv-2.7*

This patch makes the virtualenv command customizable.