### PR TITLE
Fix some byte compilation warnings

### DIFF
--- a/Cask
+++ b/Cask
@@ -5,6 +5,7 @@
 
 (depends-on "s" "1.6.1")
 (depends-on "dash" "1.5.0")
+(depends-on "projectile")
 
 (development
  (depends-on "ert-runner")


### PR DESCRIPTION
Byte compiling this package produces the following warnings:
```
In toplevel form:
virtualenvwrapper.el:33:1:Warning: defcustom for ‘venv-location’ fails to
    specify type
virtualenvwrapper.el:33:1:Warning: defcustom for ‘venv-location’ fails to
    specify type

In venv--activate-dir:
virtualenvwrapper.el:219:9:Warning: assignment to free variable
    ‘python-shell-virtualenv-path’
virtualenvwrapper.el:229:11:Warning: assignment to free variable
    ‘eshell-path-env’

In venv-deactivate:
virtualenvwrapper.el:250:9:Warning: assignment to free variable
    ‘python-shell-virtualenv-path’
virtualenvwrapper.el:258:9:Warning: assignment to free variable
    ‘eshell-path-env’

In venv-rmvirtualenv:
virtualenvwrapper.el:386:7:Warning: ‘mapcar’ called for effect; use ‘mapc’ or
    ‘dolist’ instead
virtualenvwrapper.el:406:12:Warning: called-interactively-p called with 0
    arguments, but requires 1

In venv-initialize-eshell:
virtualenvwrapper.el:542:9:Warning: assignment to free variable
    ‘eshell-modify-global-environment’
virtualenvwrapper.el:544:9:Warning: assignment to free variable
    ‘eshell-path-env’

In end of data:
virtualenvwrapper.el:563:1:Warning: the following functions are not known to
    be defined: projectile-project-root, eshell-stringify-list,
    pcomplete-here*
Done (Total of 1 file compiled)
```
This pull request fixes most of the warnings, only the ones related to the obsolete variables remains.