### PR TITLE
Fix `venv-mkvirtualenv-using' can not be called interactively or with…

### DIFF
--- a/virtualenvwrapper.el
+++ b/virtualenvwrapper.el
@@ -354,19 +354,20 @@ throwing an error if not"
 is a single directory, the new virtualenvs are made there; if it
 is a list of directories, the new virtualenvs are made in the
 current `default-directory'."
-  (interactive)
+  (interactive (list nil))
   (venv--check-executable)
-  (let* ((foo (if current-prefix-arg
-                         (read-string "Python executable: ")
-                       interpreter))
-        (parent-dir (if (stringp venv-location)
-                        (file-name-as-directory
-                         (expand-file-name venv-location))
-                      default-directory))
-        (python-exe-arg (when foo
-                          (concat "--python=" foo)))
-        (names (if names names
-                 (list (read-from-minibuffer "New virtualenv: ")))))
+  (let* ((interpreter (if (or current-prefix-arg
+                              (null interpreter))
+                          (read-string "Python executable: ")
+                        interpreter))
+         (parent-dir (if (stringp venv-location)
+                         (file-name-as-directory
+                          (expand-file-name venv-location))
+                       default-directory))
+         (python-exe-arg (when interpreter
+                           (concat "--python=" interpreter)))
+         (names (if names names
+                  (list (read-from-minibuffer "New virtualenv: ")))))
     ;; map over all the envs we want to make
     (--each names
       ;; error if this env already exists


### PR DESCRIPTION
… interpreter nil

    1. Impossible call `venv-mkvirtualenv-using' interactively.
```
Wrong number of arguments
```
Fixed with:
```elisp
(interactive (list nil))
```

    2. `venv-mkvirtualenv' calls `venv-mkvirtualenv-using' with interpreter nil

Fixed with:
```elisp
(or current-prefix-arg
    (null interpreter))
```